### PR TITLE
Add VS Code extension project, fix screenshots to use local files

### DIFF
--- a/index.html
+++ b/index.html
@@ -572,7 +572,7 @@
                         <div class="stat-label">Years Experience</div>
                     </div>
                     <div class="highlight-stat">
-                        <div class="stat-number">8+</div>
+                        <div class="stat-number">9+</div>
                         <div class="stat-label">Live Projects</div>
                     </div>
                     <div class="highlight-stat">
@@ -780,7 +780,7 @@
                     <!-- Sip on Pressed -->
                     <div class="project-card" data-type="website">
                         <div class="card-image">
-                            <img src="https://image.thum.io/get/width/700/crop/400/https://siponpressed.com/" alt="Sip on Pressed" loading="lazy">
+                            <img src="sipOnPressedWebsite.png" alt="Sip on Pressed" onerror="this.style.display='none';this.parentElement.innerHTML='<i class=\'fas fa-leaf project-icon\'></i>';">
                         </div>
                         <div class="card-body-custom">
                             <div class="project-type">Website &bull; Design Showcase</div>
@@ -803,7 +803,7 @@
                     <!-- Foley Prep -->
                     <div class="project-card" data-type="website">
                         <div class="card-image">
-                            <img src="https://image.thum.io/get/width/700/crop/400/https://foleyprep.com/" alt="Foley Prep" loading="lazy">
+                            <img src="foleyPrepWebsite.png" alt="Foley Prep">
                         </div>
                         <div class="card-body-custom">
                             <div class="project-type">Website &bull; Education Platform</div>
@@ -828,7 +828,7 @@
                     <!-- Traveling Tastebuds -->
                     <div class="project-card" data-type="website">
                         <div class="card-image">
-                            <img src="https://image.thum.io/get/width/700/crop/400/https://travelingtastebuds.org/" alt="Traveling Tastebuds" loading="lazy">
+                            <img src="ttbWebsite.png" alt="Traveling Tastebuds">
                         </div>
                         <div class="card-body-custom">
                             <div class="project-type">Website &bull; Food & Travel Blog</div>
@@ -852,7 +852,7 @@
                     <!-- SportsPick5 -->
                     <div class="project-card" data-type="website">
                         <div class="card-image">
-                            <img src="https://image.thum.io/get/width/700/crop/400/https://www.sportspick5.com/" alt="SportsPick5" loading="lazy">
+                            <img src="sportsPick5Website.png" alt="SportsPick5" onerror="this.style.display='none';this.parentElement.innerHTML='<i class=\'fas fa-football-ball project-icon\'></i>';">
                         </div>
                         <div class="card-body-custom">
                             <div class="project-type">Web App &bull; Sports & Gaming</div>
@@ -875,7 +875,7 @@
                     <!-- Rack Up Billiards -->
                     <div class="project-card" data-type="website">
                         <div class="card-image">
-                            <img src="https://image.thum.io/get/width/700/crop/400/https://rackupbilliards.com/" alt="Rack Up Billiards" loading="lazy">
+                            <img src="rackUpBilliardsWebsite.png" alt="Rack Up Billiards" onerror="this.style.display='none';this.parentElement.innerHTML='<i class=\'fas fa-circle project-icon\'></i>';">
                         </div>
                         <div class="card-body-custom">
                             <div class="project-type">Web App &bull; Sports Tracker</div>
@@ -892,6 +892,31 @@
                             <a href="https://rackupbilliards.com" target="_blank" class="visit-link">
                                 Visit Site <i class="fas fa-external-link-alt"></i>
                             </a>
+                        </div>
+                    </div>
+
+                    <!-- Unused CSS Detector -->
+                    <div class="project-card" data-type="website">
+                        <div class="card-image bg-light-gray">
+                            <i class="fas fa-broom project-icon"></i>
+                        </div>
+                        <div class="card-body-custom">
+                            <div class="project-type"><i class="fas fa-puzzle-piece"></i> VS Code Extension &bull; Developer Tool</div>
+                            <h4>Unused CSS Detector</h4>
+                            <p>A VS Code extension I built and published to the marketplace that intelligently finds unused CSS classes and IDs in your project. It follows HTML link relationships, traces JavaScript imports, supports React, Vue, PHP, and preprocessors, and automatically ignores utility frameworks like Bootstrap and Tailwind. Built for developers who care about clean, maintainable code.</p>
+                            <div class="tech-tags">
+                                <span class="tech-tag">JavaScript</span>
+                                <span class="tech-tag">VS Code API</span>
+                                <span class="tech-tag">Node.js</span>
+                                <span class="tech-tag">CSS Parsing</span>
+                                <span class="tech-tag">AST Analysis</span>
+                            </div>
+                        </div>
+                        <div class="card-footer-custom">
+                            <a href="https://marketplace.visualstudio.com/items?itemName=robwizzie.unused-css-detector" target="_blank" class="visit-link">
+                                View on Marketplace <i class="fas fa-external-link-alt"></i>
+                            </a>
+                            <span class="app-badge"><i class="fas fa-puzzle-piece"></i> Published</span>
                         </div>
                     </div>
 


### PR DESCRIPTION
- Add Unused CSS Detector VS Code Extension as a new project card with marketplace link, description, and tech tags
- Replace all broken image.thum.io URLs with local file references:
  - foleyPrepWebsite.png and ttbWebsite.png (already exist)
  - sipOnPressedWebsite.png, sportsPick5Website.png, rackUpBilliardsWebsite.png (user will add these)
- Added onerror fallback icons so cards still look clean if a screenshot file hasn't been added yet
- Bumped project count stat from 8+ to 9+

https://claude.ai/code/session_01AM2isEp7wBTYqaA6daCAMH